### PR TITLE
fix error 'Cannot reassign variable confdir_path'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,9 @@ class dnsmasq (
   $dnsmasq_logdir      = $dnsmasq::params::dnsmasq_logdir
   $dnsmasq_service     = $dnsmasq::params::dnsmasq_service
   if $confdir_path == false {
-    $confdir_path = $dnsmasq::params::dnsmasq_confdir
+    $dnsmasq_confdir = $dnsmasq::params::dnsmasq_confdir
+  } else {
+          $dnsmasq_confdir = $confdir_path
   }
 
   package { $dnsmasq_package:
@@ -42,7 +44,7 @@ class dnsmasq (
     require   => Package[$dnsmasq_package],
   }
 
-  file { $confdir_path:
+  file { $dnsmasq_confdir:
     ensure => 'directory',
   }
 

--- a/templates/dnsmasq.conf.erb
+++ b/templates/dnsmasq.conf.erb
@@ -44,6 +44,6 @@ resolv-file=<%= @resolv_file %>
 <% if @cache_size %>
 cache-size=<%= @cache_size %>
 <% end %>
-<% if @confdir_path %>
-conf-dir=<%= @confdir_path %>
+<% if @dnsmasq_confdir %>
+conf-dir=<%= @dnsmasq_confdir %>
 <% end %>


### PR DESCRIPTION
If you don't provide the class parameter `confdir_path` it cannot be reassigned from the default `false` to `$dnsmaq::params::dnsmasq_confdir`, resulting in this error message:

```
Cannot reassign variable confdir_path
```

With this patch you can use the platform default.
