### PR TITLE
resolv_conf exec: specify shell provider

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,7 @@ class dnsmasq (
   }
   
   exec { 'reload_resolvconf':
+    provider => shell,
     command => "/sbin/resolvconf -u",
     user => root,
     onlyif => "test -f /sbin/resolvconf",


### PR DESCRIPTION
- Specify shell provider to avoid error with onlyif "test -f ..."

At least on DragonFly, this fails otherwise, saying that "...is not qualified and no path was specified. Please qualify the command or specify a path."
