### PR TITLE
Added support for OracleLinux Distro:

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class dnsmasq::params {
       $dnsmasq_service = 'dnsmasq'
       $dnsmasq_package = 'dnsmasq'
     }
-    'redhat', 'centos', 'scientific', 'fedora': {
+    'redhat', 'centos', 'scientific', 'fedora', 'OracleLinux': {
       $dnsmasq_conffile = '/etc/dnsmasq.conf'
       $dnsmasq_logdir = '/var/log'
       $dnsmasq_confdir = '/etc/dnsmasq.d'


### PR DESCRIPTION
- added support for OracleLinux to params.pp

I see that you are wanting to change the facter value lookup from ::operatingsystem to
::osfamily but the values for darwin and freebsd don't
appear to be included in current facter code:
https://github.com/puppetlabs/facter/blob/master/lib/facter/osfamily.rb

Not sure what you had in mind in that case.
