### PR TITLE
Adding support for Docker containers by adding run_as_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ class { 'dnsmasq':
   no_negcache       => true,
   no_hosts          => true,
   resolv_file       => '/etc/resolv.conf',
-  cache_size        => 1000
+  cache_size        => 1000,
 }
 ```
 
@@ -201,5 +201,22 @@ dnsmasq::dnsrr { 'example-sshfp':
     domain => 'example.com',
     type   => '44',
     rdata  => '2:1:123456789abcdef67890123456789abcdef67890'
+}
+```
+
+###Running in Docker containers
+When running in a Docker container, dnsmasq tries to drop root privileges. This causes the following error:
+```
+dnsmasq: setting capabilities failed: Operation not permitted
+```
+
+In this case you can use the run\_as\_user to provide the appropriate user to run as:
+```puppet
+class { 'dnsmasq':
+  interface         => 'lo',
+  listen_address    => '192.168.39.1',
+  no_dhcp_interface => '192.168.49.1',
+  ....
+  run_as_user       => 'root',
 }
 ```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,7 @@ class dnsmasq (
   $auth_server = undef,
   $auth_sec_servers = undef,
   $auth_zone = undef,
+  $run_as_user = undef,
 ) {
 
   include dnsmasq::params

--- a/templates/dnsmasq.conf.erb
+++ b/templates/dnsmasq.conf.erb
@@ -84,6 +84,9 @@ auth-sec-servers=<%= @auth_sec_servers %>
 <% if @auth_zone -%>
 auth-zone=<%= @auth_zone %>
 <% end -%>
+<% if @run_as_user -%>
+user=<%= @run_as_user %>
+<% end -%>
 #MAIN CONFIG END
 
 # EXTENDED CONFIG


### PR DESCRIPTION
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=514214
- https://github.com/dotcloud/docker/issues/1951

dnsmasq tries to drop privileges. Setting user=<user> fixes this but is not
something you want as default obviously.
