### PR TITLE
Add server parameter to the list of accepted parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ class { 'dnsmasq':
   no_hosts          => true,
   resolv_file       => '/etc/resolv.conf',
   cache_size        => 1000,
+  server            => '8.8.8.8',
 }
 ```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@ class dnsmasq (
   $auth_sec_servers = undef,
   $auth_zone = undef,
   $run_as_user = undef,
+  $server = undef,
 ) {
 
   include dnsmasq::params

--- a/templates/dnsmasq.conf.erb
+++ b/templates/dnsmasq.conf.erb
@@ -87,6 +87,9 @@ auth-zone=<%= @auth_zone %>
 <% if @run_as_user -%>
 user=<%= @run_as_user %>
 <% end -%>
+<% if @server -%>
+server=<%= @server %>
+<% end -%>
 #MAIN CONFIG END
 
 # EXTENDED CONFIG


### PR DESCRIPTION
This allows one to use servers that are not listed in resolv.conf. This is useful in the case that you want to use resolv.conf to point the dnsmasq instance on the same machine. 8.8.8.8 is Google's main public dns server.
