### PR TITLE
Allow to disable Exec['reload_resolvconf'] option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,7 +75,7 @@ class dnsmasq (
       onlyif   => '/bin/test -f /sbin/resolvconf',
       before   => Service['dnsmasq'],
       require  => Package[$dnsmasq_package],
-   }
+    }
   }
 
   if $dnsmasq_confdir {


### PR DESCRIPTION
https://github.com/rlex/puppet-dnsmasq/issues/27
