### PR TITLE
use path param with exec. /bin/test not present in RHEL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,8 +71,9 @@ class dnsmasq (
     exec { 'reload_resolvconf':
       provider => shell,
       command  => '/sbin/resolvconf -u',
+      path     => [ '/usr/bin', '/usr/sbin', '/bin', '/sbin', ],
       user     => root,
-      onlyif   => '/bin/test -f /sbin/resolvconf',
+      onlyif   => 'test -f /sbin/resolvconf',
       before   => Service['dnsmasq'],
       require  => Package[$dnsmasq_package],
     }


### PR DESCRIPTION
RHEL needs /usr/bin/test.  Do not hardcode /bin/test.
