### PR TITLE
Add ability to pass dnsmasq's server params for dhcp

### DIFF
--- a/manifests/dhcp.pp
+++ b/manifests/dhcp.pp
@@ -4,6 +4,7 @@ define dnsmasq::dhcp (
   $dhcp_end,
   $netmask,
   $lease_time,
+  $options = [],
   $paramtag = undef,
   $paramset = undef
 ) {

--- a/templates/dhcp.erb
+++ b/templates/dhcp.erb
@@ -1,5 +1,9 @@
 <% if @dhcp_start != '' -%>
 <% tag = "tag:#{@paramtag}," if @paramtag -%>
 <% set = "set:#{@paramset}," if @paramset -%>
+<% if ! @options.kind_of?(Array) then @options = [ @options ]; end -%>
+<% @options.each do |option| -%>
+<%= option %>
+<% end -%>
 dhcp-range=<%= "#{tag}#{set}#{@dhcp_start},#{@dhcp_end},#{@netmask},#{@lease_time}" %>
 <% end -%>


### PR DESCRIPTION
Unless I'm simply a space cadet, there didn't seem to be a way for DHCP server params like 'dhcp-authoritative' to be passed along with the DHCP config. I've added an array param called "options" to dnsmasq::dhcp. dhcp.erb will auto-cast whatever is passed in options as an array anyway for safety's sake. This allows users to pass freeform string options and have them appear in the DHCP config section of dnsmasq.pp.
