### PR TITLE
remove resolv_file boolean type checking

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,7 +63,6 @@ class dnsmasq (
     $strict_order,
     $read_ethers,
     $reload_resolvconf,
-    $resolv_file,
     $restart
   )
   validate_hash($config_hash)


### PR DESCRIPTION
As the value resolv_file can sometimes be passed a non-boolean type, there should not be type validation ensuring that it is a boolean. This breaks the ability to utilize when setting a path to '/etc/resolv.conf' as the example states in the README.