### PR TITLE
Adding dhcpmatch support

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -11,7 +11,8 @@ This is API breaking update! Please consult readme & adjust your configs!
 * [FEATURE] no_resolv parameter in dnsmasq class
 * [FEATURE] dhcp_leasefile parameter in dnsmasq class
 * [FEATURE] dns_forward_max variable in dnsmasq class
-* [FEATURE] ::dhcp now supports mode => setting
+* [FEATURE] ::dhcp now supports mode => setting'
+* [FEATURE] ::dhcpmatch parameter addded.
 * [FIX] proper license name
 
 ### 2.6.1

--- a/Changelog
+++ b/Changelog
@@ -11,7 +11,7 @@ This is API breaking update! Please consult readme & adjust your configs!
 * [FEATURE] no_resolv parameter in dnsmasq class
 * [FEATURE] dhcp_leasefile parameter in dnsmasq class
 * [FEATURE] dns_forward_max variable in dnsmasq class
-* [FEATURE] ::dhcp now supports mode => setting'
+* [FEATURE] ::dhcp now supports mode => setting
 * [FEATURE] ::dhcpmatch parameter addded.
 * [FIX] proper license name
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ Will add a dhcp match. Can be used for all types of options.
 DHCP match will be inserted before 'DHCP option'.
 It can be used multiple times.
 
-
 ```puppet
 dnsmasq::dhcpmatch {'example-match':
   content: 'IPXEBOOT,175'
@@ -241,7 +240,7 @@ dnsmasq::dhcpoption { 'my-awesome-dhcp-option':
   tag     => 'sometag', #optional
 }
 ```
- 
+
 ### DHCP booting (PXE)
 
 Allows you to setup different PXE servers in different subnets.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ dnsmasq::dhcpstatic { 'example-host':
 }
 ```
 
+### DHCP match configuration
+
+Will add a dhcp match. Can be used for all types of options.
+DHCP match will be inserted before 'DHCP option'.
+It can be used multiple times.
+
+
+```puppet
+dnsmasq::dhcpmatch {'example-match':
+  content: 'IPXEBOOT,175'
+}
+```
+
 ### Host record configuration
 
 Will add static A, AAAA (if provided) and PTR record
@@ -228,7 +241,7 @@ dnsmasq::dhcpoption { 'my-awesome-dhcp-option':
   tag     => 'sometag', #optional
 }
 ```
-
+ 
 ### DHCP booting (PXE)
 
 Allows you to setup different PXE servers in different subnets.

--- a/manifests/address.pp
+++ b/manifests/address.pp
@@ -8,7 +8,7 @@ define dnsmasq::address (
   include dnsmasq
 
   concat::fragment { "dnsmasq-staticdns-${name}":
-    order   => "06_${name}",
+    order   => "07_${name}",
     target  => 'dnsmasq.conf',
     content => template('dnsmasq/address.erb'),
   }

--- a/manifests/cname.pp
+++ b/manifests/cname.pp
@@ -8,7 +8,7 @@ define dnsmasq::cname (
   include dnsmasq
 
   concat::fragment { "dnsmasq-cname-${name}":
-    order   => '11',
+    order   => '12',
     target  => 'dnsmasq.conf',
     content => template('dnsmasq/cname.erb'),
   }

--- a/manifests/dhcpboot.pp
+++ b/manifests/dhcpboot.pp
@@ -22,7 +22,7 @@ define dnsmasq::dhcpboot (
   include dnsmasq
 
   concat::fragment { "dnsmasq-dhcpboot-${name}":
-    order   => '03',
+    order   => '04',
     target  => 'dnsmasq.conf',
     content => template('dnsmasq/dhcpboot.erb'),
   }

--- a/manifests/dhcpmatch.pp
+++ b/manifests/dhcpmatch.pp
@@ -8,7 +8,7 @@ define dnsmasq::dhcpmatch (
   $dnsmasq_conffile = $dnsmasq::params::dnsmasq_conffile
 
   concat::fragment { "dnsmasq-dhcpmatch-${name}":
-    order   => '01',
+    order   => '02',
     target  => $dnsmasq_conffile,
     content => template('dnsmasq/dhcpmatch.erb'),
   }

--- a/manifests/dhcpmatch.pp
+++ b/manifests/dhcpmatch.pp
@@ -1,0 +1,15 @@
+# Create a dnsmasq dhcp match
+define dnsmasq::dhcpmatch (
+  $content,
+  $paramtag = undef,
+) {
+  include dnsmasq::params
+
+  $dnsmasq_conffile = $dnsmasq::params::dnsmasq_conffile
+
+  concat::fragment { "dnsmasq-dhcpmatch-${name}":
+    order   => '01',
+    target  => $dnsmasq_conffile,
+    content => template('dnsmasq/dhcpmatch.erb'),
+  }
+}

--- a/manifests/dhcpoption.pp
+++ b/manifests/dhcpoption.pp
@@ -12,7 +12,7 @@ define dnsmasq::dhcpoption (
   include dnsmasq
 
   concat::fragment { "dnsmasq-dhcpoption-${name}":
-    order   => '02',
+    order   => '03',
     target  => 'dnsmasq.conf',
     content => template('dnsmasq/dhcpoption.erb'),
   }

--- a/manifests/dhcpstatic.pp
+++ b/manifests/dhcpstatic.pp
@@ -14,7 +14,7 @@ define dnsmasq::dhcpstatic (
   include dnsmasq
 
   concat::fragment { "dnsmasq-staticdhcp-${name}":
-    order   => '04',
+    order   => '05',
     target  => 'dnsmasq.conf',
     content => template('dnsmasq/dhcpstatic.erb'),
   }

--- a/manifests/dnsrr.pp
+++ b/manifests/dnsrr.pp
@@ -13,7 +13,7 @@ define dnsmasq::dnsrr (
   include dnsmasq
 
   concat::fragment { "dnsmasq-dnsrr-${name}":
-    order   => '11',
+    order   => '12',
     target  => 'dnsmasq.conf',
     content => template('dnsmasq/dnsrr.erb'),
   }

--- a/manifests/dnsserver.pp
+++ b/manifests/dnsserver.pp
@@ -20,7 +20,7 @@ define dnsmasq::dnsserver (
   include dnsmasq
 
   concat::fragment { "dnsmasq-dnsserver-${name}":
-    order   => '12',
+    order   => '13',
     target  => 'dnsmasq.conf',
     content => template('dnsmasq/dnsserver.erb'),
   }

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -16,7 +16,7 @@ define dnsmasq::domain (
   }
 
   concat::fragment { "dnsmasq-domain-${name}":
-    order   => '05',
+    order   => '06',
     target  => 'dnsmasq.conf',
     content => template('dnsmasq/domain.erb'),
   }

--- a/manifests/hostrecord.pp
+++ b/manifests/hostrecord.pp
@@ -13,7 +13,7 @@ define dnsmasq::hostrecord (
   }
 
   concat::fragment { "dnsmasq-hostrecord-${name}":
-    order   => '06',
+    order   => '07',
     target  => 'dnsmasq.conf',
     content => template('dnsmasq/hostrecord.erb'),
   }

--- a/manifests/mx.pp
+++ b/manifests/mx.pp
@@ -21,7 +21,7 @@ define dnsmasq::mx (
 
   concat::fragment { "dnsmasq-mx-${name}":
     # prevent "reordering" changes
-    order   => "07_${mx_name}_${hostname_real}_${preference_real}",
+    order   => "08_${mx_name}_${hostname_real}_${preference_real}",
     target  => 'dnsmasq.conf',
     content => template('dnsmasq/mx.erb'),
   }

--- a/manifests/ptr.pp
+++ b/manifests/ptr.pp
@@ -5,7 +5,7 @@ define dnsmasq::ptr (
   include dnsmasq
 
   concat::fragment { "dnsmasq-ptr-${name}":
-    order   => '09',
+    order   => '10',
     target  => 'dnsmasq.conf',
     content => template('dnsmasq/ptr.erb'),
   }

--- a/manifests/srv.pp
+++ b/manifests/srv.pp
@@ -15,7 +15,7 @@ define dnsmasq::srv (
   include dnsmasq
 
   concat::fragment { "dnsmasq-srv-${name}":
-    order   => '08',
+    order   => '09',
     target  => 'dnsmasq.conf',
     content => template('dnsmasq/srv.erb'),
   }

--- a/manifests/txt.pp
+++ b/manifests/txt.pp
@@ -5,7 +5,7 @@ define dnsmasq::txt(
   include dnsmasq
 
   concat::fragment { "dnsmasq-txt-${name}":
-    order   => '10',
+    order   => '11',
     target  => 'dnsmasq.conf',
     content => template('dnsmasq/txt.erb'),
   }

--- a/templates/dhcpmatch.erb
+++ b/templates/dhcpmatch.erb
@@ -1,0 +1,4 @@
+<% if @content != '' -%>
+<% tag = "#{@paramtag}," if @paramtag -%>
+<%= "dhcp-match=#{tag}#{@content}\n" -%>
+<% end -%>


### PR DESCRIPTION
This adds support for an entry like 'dhcp-match: xxxxx' in the dnsmasq config files. Needed this for get the module working with puppetlabs razor and network booting.