### PR TITLE
correcting concat target

### DIFF
--- a/manifests/dhcpmatch.pp
+++ b/manifests/dhcpmatch.pp
@@ -9,7 +9,7 @@ define dnsmasq::dhcpmatch (
 
   concat::fragment { "dnsmasq-dhcpmatch-${name}":
     order   => '02',
-    target  => $dnsmasq_conffile,
+    target  => 'dnsmasq.conf',
     content => template('dnsmasq/dhcpmatch.erb'),
   }
 }


### PR DESCRIPTION
The concat target here doesn't look like it's the concat object created in the dhcpoption.pp file. This causes the option to fail when used in hiera or a manifest.