### PR TITLE
adding support for proxydhcp

### DIFF
--- a/manifests/pxe_service.pp
+++ b/manifests/pxe_service.pp
@@ -1,0 +1,15 @@
+# Create a dnsmasq pxe-service
+define dnsmasq::pxe_service (
+  $content,
+  $paramtag = undef,
+) {
+  include dnsmasq::params
+
+  $dnsmasq_conffile = $dnsmasq::params::dnsmasq_conffile
+
+  concat::fragment { "dnsmasq-pxe_service-${name}":
+    order   => '02',
+    target  => 'dnsmasq.conf',
+    content => template('dnsmasq/pxe_service.erb'),
+  }
+}

--- a/templates/pxe_service.erb
+++ b/templates/pxe_service.erb
@@ -1,0 +1,4 @@
+<% if @content != '' -%>
+<% tag = "#{@paramtag}," if @paramtag -%>
+<%= "pxe-service=x86PC,\"#{@name}\",#{@content}, #{@ipaddress}\n" -%>
+<% end -%>


### PR DESCRIPTION
This allows us to configure the dnsmasq pxe-service configuration line in the dnsmasq.conf file.
This is necessary for using dnsmasq as a proxydhcp server.