### PR TITLE
Allow writing using rev-server syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,15 @@ dnsmasq::dnsserver { 'forward-zone':
   port   => '9001', #optional
 }
 ```
-
+And using alternative syntax
+```puppet
+dnsmasq::dnsserver { 'forward-zone-rev':
+  subnet  => '192.168.196.1',
+  netmask => '24',
+  ip      => '192.168.39.1',
+  port    => '9001', #optional
+}
+```
 ### DNS-RR records
 Allows dnsmasq to serve arbitrary records, for example:
 ```puppet

--- a/manifests/dnsrevserver.pp
+++ b/manifests/dnsrevserver.pp
@@ -1,0 +1,24 @@
+# Configure the DNS server to query sub domains to external DNS servers
+# (--rev-server).
+define dnsmasq::dnsrevserver (
+  $ip,
+  $netmask,
+  $subnet,
+  $port = undef,
+) {
+  if !is_ip_address($ip) { fail("Expect IP address for ip, got ${ip}") }
+  if !is_ip_address($subnet) { fail("Expect IP address for subnet, got ${subnet}") }
+
+  $port_real = $port ? {
+    undef   => '',
+    default => "#${port}",
+  }
+
+  include dnsmasq
+
+  concat::fragment { "dnsmasq-dnsserver-${name}":
+    order   => '13',
+    target  => 'dnsmasq.conf',
+    content => template('dnsmasq/dnsrevserver.erb'),
+  }
+}

--- a/templates/dnsrevserver.erb
+++ b/templates/dnsrevserver.erb
@@ -1,0 +1,1 @@
+rev-server=<%= @subnet %>/<%= @netmask %>,<%= @ip %><%= @port_real %>


### PR DESCRIPTION
Add an entry to allow users to write server entries to dnsmasq.conf using the alternative syntax, making reverse dns easier